### PR TITLE
Allow selecting children of selected parent nodes

### DIFF
--- a/kolibri_dynamic_collections_plugin/assets/src/components/CollectionContentNodeCheckbox.vue
+++ b/kolibri_dynamic_collections_plugin/assets/src/components/CollectionContentNodeCheckbox.vue
@@ -1,10 +1,10 @@
 <template>
 
   <KCheckbox
-    :checked="isNodeToggled"
-    :indeterminate="isNodeIndeterminate"
+    :checked="isSelected"
+    :indeterminate="isSelectedIndirectly"
+    :class="{ 'selected-indirectly': isSelectedIndirectly }"
     :title="$tr('checkboxTooltip')"
-    :disabled="!isNodeEnabled"
     :style="{ marginTop: 0, marginBottom: 0 }"
     @change="onNodeCheckboxToggled"
   />
@@ -23,43 +23,24 @@
         type: Object,
         required: true,
       },
-      selectedNodeIds: {
-        type: Array,
-        required: true,
+      isSelected: {
+        type: Boolean,
+        default: false,
+      },
+      isAncestorSelected: {
+        type: Boolean,
+        default: false,
       },
     },
     computed: {
       nodeId() {
         return this.contentNode.id;
       },
-      ancestorNodeIds() {
-        return this.contentNode.ancestors.map(node => node.id);
-      },
-      isNodeToggled() {
-        // TODO: Instead of doing this locally, update AllContentNodeViewset
-        //       to accept a content manifest as request payload and annotate
-        //       results to describe whether nodes are included.
-        if (this.selectedNodeIds === undefined) {
-          return true;
-        }
-        return this.getNodeEnabled(this.nodeId) || this.ancestorNodeIds.some(this.getNodeEnabled);
-      },
-      isNodeIndeterminate() {
-        // TODO: If children are selected but not this node, it should appear
-        //       as indeterminate.
-        return false;
-      },
-      isNodeEnabled() {
-        // TODO: If parent node is included, this node is marked as toggled,
-        //       and also disabled. Parent must be explicitly deselected
-        //       first.
-        return !this.ancestorNodeIds.some(this.getNodeEnabled);
+      isSelectedIndirectly() {
+        return this.isAncestorSelected && !this.isSelected;
       },
     },
     methods: {
-      getNodeEnabled(nodeId) {
-        return this.selectedNodeIds.indexOf(nodeId) >= 0;
-      },
       onNodeCheckboxToggled(value) {
         this.$emit('toggle', {
           nodeId: this.nodeId,
@@ -76,3 +57,12 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .selected-indirectly {
+    opacity: 0.5;
+  }
+
+</style>

--- a/kolibri_dynamic_collections_plugin/assets/src/components/CollectionContentNodeTable.vue
+++ b/kolibri_dynamic_collections_plugin/assets/src/components/CollectionContentNodeTable.vue
@@ -6,7 +6,7 @@
         <span class="visuallyhidden">
           {{ $tr('selectedHeader') }}
         </span>
-        <slot name="nodeActions" :contentNode="topic"></slot>
+        <slot name="nodeActions" v-bind="buildContentNodeProps(topic)"></slot>
       </th>
       <th class="content-node-thumbnail-column">
         <span class="visuallyhidden">
@@ -26,7 +26,10 @@
           :contentNode="contentNode"
         >
           <template #actions>
-            <slot name="nodeActions" :contentNode="contentNode"></slot>
+            <slot name="nodeActions" v-bind="buildContentNodeProps(contentNode)"></slot>
+          </template>
+          <template #extraActions>
+            <slot name="nodeExtraActions" v-bind="buildContentNodeProps(contentNode)"></slot>
           </template>
         </CollectionContentNodeTableRow>
       </tbody>
@@ -55,6 +58,28 @@
       children: {
         type: Array,
         default: () => [],
+      },
+      selectedNodeIds: {
+        type: Array,
+        required: true,
+      },
+    },
+    methods: {
+      buildContentNodeProps(contentNode) {
+        return {
+          contentNode,
+          isSelected: this.isNodeSelected(contentNode),
+          isAncestorSelected: this.isNodeAncestorSelected(contentNode),
+        };
+      },
+      isNodeSelected(contentNode) {
+        // TODO: Instead of doing this locally, update AllContentNodeViewset
+        //       to accept a content manifest as request payload and annotate
+        //       results to describe whether nodes are included.
+        return this.selectedNodeIds.indexOf(contentNode.id) >= 0;
+      },
+      isNodeAncestorSelected(contentNode) {
+        return contentNode.ancestors.some(ancestorNode => this.isNodeSelected(ancestorNode));
       },
     },
     $trs: {

--- a/kolibri_dynamic_collections_plugin/assets/src/views/CollectionEditorChannelPage.vue
+++ b/kolibri_dynamic_collections_plugin/assets/src/views/CollectionEditorChannelPage.vue
@@ -19,11 +19,13 @@
         class="collection-channel-content"
         :topic="topic"
         :children="children"
+        :selectedNodeIds="selectedNodeIds"
       >
-        <template #nodeActions="{ contentNode }">
+        <template #nodeActions="{ contentNode, isAncestorSelected, isSelected }">
           <CollectionContentNodeCheckbox
             :contentNode="contentNode"
-            :selectedNodeIds="selectedNodeIds"
+            :isSelected="isSelected"
+            :isAncestorSelected="isAncestorSelected"
             @toggle="onCollectionContentNodeCheckboxToggled"
           />
         </template>


### PR DESCRIPTION
We will use an indeterminate state to indicate content nodes which are selected indirectly. That is, which are included inside a selected topic node. A node in this state can still be explicitly selected or deselected. With this change, the checkboxes for content nodes are always interactive.

https://phabricator.endlessm.com/T34503